### PR TITLE
공통 응답 & 공통 예외처리 구현

### DIFF
--- a/backend/src/main/java/com/techeer/backend/global/common/response/CommonResponse.java
+++ b/backend/src/main/java/com/techeer/backend/global/common/response/CommonResponse.java
@@ -1,0 +1,39 @@
+package com.techeer.backend.global.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.techeer.backend.global.common.status.BaseStatus;
+import com.techeer.backend.global.success.SuccessStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class CommonResponse<T> {
+
+    @Getter(AccessLevel.NONE)
+    @JsonProperty("isSuccess")
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private final T result;
+
+    // 성공시 응답 생성
+    public static <T> CommonResponse<T> onSuccess(T result) {
+        return new CommonResponse<>(true, SuccessStatus.OK.getCode(), SuccessStatus.OK.getMessage(), result);
+    }
+
+    public static <T> CommonResponse<T> of(BaseStatus status, T result) {
+        return new CommonResponse<>(true, status.getReason().getCode(), status.getReason().getMessage(), result);
+    }
+
+    // 실패시 응답 생성
+    public static <T> CommonResponse<T> onFailure(String code, String message, T data) {
+        return new CommonResponse<>(false, code, message, data);
+    }
+
+}

--- a/backend/src/main/java/com/techeer/backend/global/common/response/ReasonDto.java
+++ b/backend/src/main/java/com/techeer/backend/global/common/response/ReasonDto.java
@@ -1,0 +1,19 @@
+package com.techeer.backend.global.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDto {
+
+    private HttpStatus status;
+    private boolean isSuccess;
+    private String code;
+    private String message;
+
+    public boolean isSuccess() {
+        return isSuccess;
+    }
+}

--- a/backend/src/main/java/com/techeer/backend/global/common/status/BaseStatus.java
+++ b/backend/src/main/java/com/techeer/backend/global/common/status/BaseStatus.java
@@ -1,0 +1,9 @@
+package com.techeer.backend.global.common.status;
+
+import com.techeer.backend.global.common.response.ReasonDto;
+
+public interface BaseStatus {
+    public ReasonDto getReason();
+
+    public ReasonDto getReasonHttpStatus();
+}

--- a/backend/src/main/java/com/techeer/backend/global/error/ErrorStatus.java
+++ b/backend/src/main/java/com/techeer/backend/global/error/ErrorStatus.java
@@ -1,0 +1,42 @@
+package com.techeer.backend.global.error;
+
+import com.techeer.backend.global.common.response.ReasonDto;
+import com.techeer.backend.global.common.status.BaseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseStatus {
+    // Common Error
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 에러입니다. 관리자에게 문의하세요."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
+    ;
+    // User Error
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .status(httpStatus)
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/techeer/backend/global/error/exception/ExceptionAdvice.java
+++ b/backend/src/main/java/com/techeer/backend/global/error/exception/ExceptionAdvice.java
@@ -1,0 +1,126 @@
+package com.techeer.backend.global.error.exception;
+
+
+import com.techeer.backend.global.common.response.CommonResponse;
+import com.techeer.backend.global.common.response.ReasonDto;
+import com.techeer.backend.global.error.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.springframework.beans.InvalidPropertyException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "ConstraintViolationException이 ConstraintViolation을 포함하지 않습니다."));
+
+        ErrorStatus errorStatus = ErrorStatus.BAD_REQUEST;
+        for (ErrorStatus value : ErrorStatus.values()) {
+            if (value.name().equals(errorMessage)) {
+                errorStatus = value;
+                break;
+            }
+        }
+
+        return handleExceptionInternalConstraint(e, errorStatus, HttpHeaders.EMPTY, request);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatusCode status,
+                                                                  WebRequest request) {
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors()
+                .forEach(fieldError -> {
+                    String fieldName = fieldError.getField();
+                    String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+                    errors.merge(fieldName, errorMessage,
+                            (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);
+                });
+
+        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, ErrorStatus.BAD_REQUEST, request, errors);
+    }
+
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity<Object> handleGeneral(GeneralException generalException, HttpServletRequest request) {
+        ReasonDto errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+
+        return handleExceptionInternalGeneral(generalException, errorReasonHttpStatus, null, request);
+    }
+
+    @ExceptionHandler(InvalidPropertyException.class)
+    protected ResponseEntity<?> handleInvalidPropertyException(InvalidPropertyException e,
+                                                               WebRequest request) {
+
+        ErrorStatus errorStatus = ErrorStatus.BAD_REQUEST;
+        return handleExceptionInternalConstraint(e, errorStatus, HttpHeaders.EMPTY, request);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> handleOthers(Exception e, WebRequest request) {
+        return handleExceptionInternalOthers(e, ErrorStatus.INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,
+                ErrorStatus.INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        CommonResponse<Object> body = CommonResponse.onFailure(errorStatus.getCode(),
+                errorStatus.getMessage(),
+                null);
+
+        return super.handleExceptionInternal(e, body, headers, errorStatus.getHttpStatus(), request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers,
+                                                               ErrorStatus errorStatus,
+                                                               WebRequest request,
+                                                               Map<String, String> errorArgs) {
+        CommonResponse<Object> body = CommonResponse.onFailure(errorStatus.getCode(),
+                errorStatus.getMessage(),
+                errorArgs);
+
+        return super.handleExceptionInternal(e, body, headers, errorStatus.getHttpStatus(), request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalGeneral(Exception e,
+                                                                  ReasonDto reason,
+                                                                  HttpHeaders headers,
+                                                                  HttpServletRequest request) {
+        CommonResponse<Object> body = CommonResponse.onFailure(reason.getCode(),
+                reason.getMessage(),
+                null);
+
+        return super.handleExceptionInternal(e, body, headers, reason.getStatus(), new ServletWebRequest(request));
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalOthers(Exception e, ErrorStatus errorStatus,
+                                                                 HttpHeaders headers, HttpStatus status,
+                                                                 WebRequest request, String errorPoint) {
+        CommonResponse<Object> body = CommonResponse.onFailure(errorStatus.getCode(),
+                errorStatus.getMessage(),
+                errorPoint);
+
+        return super.handleExceptionInternal(e, body, headers, status, request);
+    }
+}

--- a/backend/src/main/java/com/techeer/backend/global/error/exception/GeneralException.java
+++ b/backend/src/main/java/com/techeer/backend/global/error/exception/GeneralException.java
@@ -1,0 +1,20 @@
+package com.techeer.backend.global.error.exception;
+
+import com.techeer.backend.global.common.response.ReasonDto;
+import com.techeer.backend.global.common.status.BaseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+    private final BaseStatus status;
+
+    public ReasonDto getErrorReason() {
+        return this.status.getReason();
+    }
+
+    public ReasonDto getErrorReasonHttpStatus() {
+        return this.status.getReasonHttpStatus();
+    }
+}

--- a/backend/src/main/java/com/techeer/backend/global/success/SuccessStatus.java
+++ b/backend/src/main/java/com/techeer/backend/global/success/SuccessStatus.java
@@ -1,0 +1,40 @@
+package com.techeer.backend.global.success;
+
+import com.techeer.backend.global.common.response.ReasonDto;
+import com.techeer.backend.global.common.status.BaseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseStatus {
+    // Common Success
+    OK(HttpStatus.OK, "COMMON_200", "성공적으로 처리되었습니다."),
+    CREATED(HttpStatus.CREATED, "COMMON_201", "성공적으로 생성되었습니다."),
+    NO_CONTENT(HttpStatus.NO_CONTENT, "COMMON_204", "성공적으로 삭제되었습니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDto getReason() {
+        return ReasonDto.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .status(httpStatus)
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+}


### PR DESCRIPTION
## 변경 사항
공통 응답 및 예외처리 구현했습니다.
- 공통 응답 (성공여부, 코드, HttpStatus, 값)을 반환
- 일반 예외처리 (GeneralException을 통해 예외 발생 시 코드, HttpStatus 반환할 수 있도록 하였습니다)


## +α Checklist
- [ ] 자바 코드 컨벤션을 지키면서 프로그래밍했는가?
- [ ] 한 메서드에 오직 한 단계의 들여쓰기(indent)만 허용했는가?
- [ ] else 예약어를 쓰지 않았는가?
- [ ] 모든 원시값과 문자열을 포장했는가?
- [ ] 콜렉션에 대해 일급 콜렉션을 적용했는가?
- [ ] 3개 이상의 인스턴스 변수를 가진 클래스를 구현하지 않았는가? (가능하면 인스턴스 변수의 수를 줄이기 위해 노력한다.)
- [ ] getter/setter 없이 구현했는가? (단, DTO는 허용한다.)
- [ ] 메소드의 인자 수를 제한했는가? (4개 이상의 인자는 허용하지 않는다. 3개도 가능하면 줄이기 위해 노력해 본다.)
- [ ] 코드 한 줄에 점(.)을 하나만 허용했는가?
- [ ] 메소드가 한가지 일만 담당하도록 구현했는가?
- [ ] 클래스를 작게 유지하기 위해 노력했는가?